### PR TITLE
Add Siri voice activation for hands-free session control

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ meta-glasses-ios-openai/
 └── AudioManager.swift      # Bluetooth HFP audio
 ```
 
+## Siri Voice Activation
+
+You can start the voice assistant hands-free using Siri:
+
+| Action | What to say |
+|--------|-------------|
+| **Start session** | "Hey Siri, start session with Glasses" |
+| **Stop session** | "Stop session" *(said to the AI, not Siri)* |
+
+**Limitation:** "Hey Siri" is heard by your iPhone, not the glasses. If your phone is too far away or in a bag, Siri won't hear you. The glasses microphone cannot trigger Siri — this is an iOS limitation.
+
+*Future: When Meta enables custom button actions on glasses, this can be improved.*
+
 ## License
 
 [MIT](LICENSE)

--- a/meta-glasses-ios-openai/ContentView.swift
+++ b/meta-glasses-ios-openai/ContentView.swift
@@ -49,6 +49,7 @@ struct ContentView: View {
     @StateObject private var glassesManager = GlassesManager()
     @ObservedObject private var permissionsManager = PermissionsManager.shared
     @ObservedObject private var settingsManager = SettingsManager.shared
+    @ObservedObject private var voiceTrigger = VoiceAgentTrigger.shared
     
     var body: some View {
         Group {
@@ -82,6 +83,13 @@ struct ContentView: View {
                 }
                 .onChange(of: selectedTab) { oldValue, newValue in
                     logger.info("📑 Tab changed: \(oldValue.name) → \(newValue.name)")
+                }
+                .onChange(of: voiceTrigger.shouldStartVoiceAgent) { oldValue, newValue in
+                    // Handle Siri trigger: switch to Voice Agent tab
+                    if newValue && !oldValue {
+                        logger.info("🎙️ Siri triggered Voice Agent - switching to Voice Agent tab")
+                        selectedTab = .voiceAgent
+                    }
                 }
             } else {
                 LoadingView()

--- a/meta-glasses-ios-openai/Info.plist
+++ b/meta-glasses-ios-openai/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- App display name (used by Siri and on home screen) -->
+	<key>CFBundleDisplayName</key>
+	<string>Glasses</string>
+	
 	<!-- Bluetooth permission for glasses connection -->
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Bluetooth is required to connect to your Meta Glasses. Without Bluetooth access, this app cannot function.</string>

--- a/meta-glasses-ios-openai/MetaGlassesApp.swift
+++ b/meta-glasses-ios-openai/MetaGlassesApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import MWDATCore
+import AppIntents
 import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "meta-glasses-ios-openai", category: "App")
@@ -23,6 +24,10 @@ struct MetaGlassesApp: App {
             logger.error("❌ Failed to configure Wearables SDK: \(error.localizedDescription)")
             fatalError("Failed to configure Wearables SDK: \(error)")
         }
+        
+        // Register Siri Shortcuts for voice activation
+        MetaGlassesShortcuts.updateAppShortcutParameters()
+        logger.info("✅ Siri Shortcuts registered")
     }
     
     var body: some Scene {

--- a/meta-glasses-ios-openai/RealtimeAPIClient.swift
+++ b/meta-glasses-ios-openai/RealtimeAPIClient.swift
@@ -404,6 +404,9 @@ final class RealtimeAPIClient: ObservableObject {
     func disconnect() {
         logger.info("Disconnecting from Realtime API")
         
+        // Play disconnect sound
+        SoundManager.shared.playDisconnectSound()
+        
         // Save messages to thread before clearing
         ThreadsManager.shared.saveMessages(messages: messages)
         ThreadsManager.shared.finalizeActiveThread()
@@ -1470,6 +1473,15 @@ final class RealtimeAPIClient: ObservableObject {
                     ThreadsManager.shared.saveMessages(messages: messages)
                 }
                 logger.info("👤 User: \(transcript)")
+                
+                // Check for stop phrases to end the conversation (case-insensitive)
+                let stopPhrases = ["Stop session"]
+                let lowerTranscript = transcript.lowercased()
+                if stopPhrases.contains(where: { lowerTranscript.contains($0.lowercased()) }) {
+                    logger.info("🛑 Stop phrase detected - disconnecting")
+                    disconnect()
+                    return
+                }
                 
                 // Add to recent transcripts for context
                 recentTranscripts.append(transcript)

--- a/meta-glasses-ios-openai/SiriIntents.swift
+++ b/meta-glasses-ios-openai/SiriIntents.swift
@@ -1,0 +1,68 @@
+//
+//  SiriIntents.swift
+//  meta-glasses-ios-openai
+//
+//  Siri Shortcuts integration for Voice Agent
+//
+
+import AppIntents
+import Combine
+import os.log
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "meta-glasses-ios-openai", category: "SiriIntents")
+
+// MARK: - Voice Agent Trigger
+
+/// Observable singleton that bridges Siri Intent and UI
+/// When Siri triggers the intent, this flag is set to true
+/// VoiceAgentView observes this and auto-connects
+@MainActor
+final class VoiceAgentTrigger: ObservableObject {
+    static let shared = VoiceAgentTrigger()
+    
+    @Published var shouldStartVoiceAgent: Bool = false
+    
+    private init() {}
+    
+    /// Reset the trigger after handling
+    func reset() {
+        shouldStartVoiceAgent = false
+    }
+}
+
+// MARK: - Start Voice Agent Intent
+
+/// App Intent that starts the Voice Agent when triggered by Siri
+struct StartVoiceAgentIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start AI Assistant"
+    static let description = IntentDescription("Start a voice conversation with AI through your Meta Glasses")
+    
+    /// When true, the app will be launched/brought to foreground when this intent runs
+    static let openAppWhenRun: Bool = true
+    
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        logger.info("🎙️ Siri triggered StartVoiceAgentIntent")
+        VoiceAgentTrigger.shared.shouldStartVoiceAgent = true
+        return .result()
+    }
+}
+
+// MARK: - App Shortcuts Provider
+
+/// Registers App Shortcuts with Siri
+/// These phrases will be recognized by Siri even when the app is closed
+struct MetaGlassesShortcuts: AppShortcutsProvider {
+    
+    @AppShortcutsBuilder
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: StartVoiceAgentIntent(),
+            phrases: [
+                "Start session with \(.applicationName)",
+            ],
+            shortTitle: "Start AI Assistant",
+            systemImageName: "waveform.circle"
+        )
+    }
+}

--- a/meta-glasses-ios-openai/SoundManager.swift
+++ b/meta-glasses-ios-openai/SoundManager.swift
@@ -34,6 +34,13 @@ final class SoundManager {
         playTone(frequencies: [660], duration: 0.1, pause: 0)
     }
     
+    /// Play sound when Voice Agent session ends
+    /// Short descending two-tone chime (ending/goodbye feeling)
+    func playDisconnectSound() {
+        logger.info("🔔 Playing disconnect sound")
+        playTone(frequencies: [1320, 880], duration: 0.08, pause: 0.05)
+    }
+    
     /// Generate and play a sequence of sine wave tones
     private func playTone(frequencies: [Double], duration: Double, pause: Double) {
         let sampleRate: Double = 44100


### PR DESCRIPTION
## Summary

- Add Siri Shortcuts integration to start voice agent with "Hey Siri, start session with Glasses"
- Add stop phrase detection to end sessions by saying "Stop session" to the AI
- Add audio feedback (descending chime) when session ends

## Details

- New `SiriIntents.swift` with `StartVoiceAgentIntent` and `MetaGlassesShortcuts`
- `VoiceAgentTrigger` singleton bridges Siri intent with UI
- App display name set to "Glasses" for cleaner Siri phrases
- Documentation updated in README

## Limitation

"Hey Siri" is heard by iPhone, not glasses. This is an iOS limitation until Meta enables custom button actions.